### PR TITLE
Instrument exec.Command

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -62,7 +62,7 @@ func New(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, dir, na
 		cmd: exec.CommandContext(ctx, name, args...),
 	}
 	cmd.cmd.Dir = dir
-	// NOTE: GIT_DIR requires abolute paths, and `dir` is relative for now...
+	// NOTE: GIT_DIR requires abolute paths, and `dir` can be relative for now...
 	//cmd.cmd.Env = append(cmd.cmd.Env, fmt.Sprintf("GIT_DIR=%s", dir))
 
 	if stdout == nil {

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -44,7 +44,7 @@ func New(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, dir, na
 	// NOTE: This span is Finish()ed in Wait() or Finish()...
 	span, ctx := opentracing.StartSpanFromContext(ctx, "command.New")
 	span.SetTag("name", name)
-	span.SetTag("args", fmt.Sprintf("%v", args))
+	span.SetTag("args", fmt.Sprintf("%q", args))
 	span.SetTag("dir", dir)
 	cmd := &command{
 		cmd: exec.CommandContext(ctx, name, args...),

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -15,6 +15,9 @@ import (
 var wgAll sync.WaitGroup
 
 // WaitAll waits for all Commands to finish
+// TODO: This waits for all commands to run to completion
+//   This is so we don't kill any stray "git merge" or other
+//   writing commands, which could leave things corrupt
 func WaitAll() {
 	wgAll.Wait()
 }
@@ -40,6 +43,7 @@ type (
 		span   opentracing.Span
 	}
 
+	// Option ...
 	Option func(*command) error
 )
 

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -36,6 +37,17 @@ type command struct {
 	stderr io.ReadCloser
 	stdin  io.WriteCloser
 	span   opentracing.Span
+}
+
+// NewSimple is for when you would usually exec.Cmd.Run() something
+func NewSimple(ctx context.Context, dir, name string, args ...string) (string, error) {
+	buf := &bytes.Buffer{}
+	cmd, err := New(ctx, nil, buf, buf, dir, name, args...)
+	if err != nil {
+		return "", err
+	}
+	err = cmd.Wait()
+	return buf.String(), err
 }
 
 // New creates a new Command

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -52,6 +52,7 @@ func NewSimple(ctx context.Context, dir, name string, args ...string) (string, e
 
 // New creates a new Command
 //  The caller is required to call Wait() or Finish() for the tracing to work
+//  when `stdin`/`stdout`/`stderr` is `nil`, a Pipe will be setup. Use `Stdin()` etc to get them.
 func New(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, dir, name string, args ...string) (Command, error) {
 	// NOTE: This span is Finish()ed in Wait() or Finish()...
 	span, ctx := opentracing.StartSpanFromContext(ctx, "command.New")

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -1,0 +1,88 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+)
+
+// Command defines the interface for all shellouts
+type Command interface {
+	Stdout() io.Reader
+	Stderr() io.Reader
+	Stdin() io.Writer
+
+	Wait() error
+}
+
+var wgAll sync.WaitGroup
+
+type command struct {
+	cmd    *exec.Cmd
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+	stdin  io.WriteCloser
+	span   opentracing.Span
+}
+
+// New creates a new Command
+func New(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, dir, name string, args ...string) (*command, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "command.New")
+	span.SetTag("args", fmt.Sprintf("%v", args))
+	cmd := &command{
+		cmd: exec.CommandContext(ctx, name, args...),
+	}
+	cmd.cmd.Dir = dir
+	cmd.cmd.Env = append(cmd.cmd.Env, fmt.Sprintf("GIT_DIR=%s", dir))
+
+	if stdout == nil {
+		var err error
+		cmd.stdout, err = cmd.cmd.StdoutPipe()
+		if err != nil {
+			return nil, errors.Wrap(err, "StdoutPipe")
+		}
+	} else {
+		cmd.cmd.Stdout = stdout
+	}
+	if stderr == nil {
+		var err error
+		cmd.stderr, err = cmd.cmd.StderrPipe()
+		if err != nil {
+			return nil, errors.Wrap(err, "StderrPipe")
+		}
+	} else {
+		cmd.cmd.Stderr = stderr
+	}
+
+	wgAll.Add(1)
+	return cmd, cmd.cmd.Start()
+}
+
+func (c *command) Stdout() io.Reader {
+	return c.stdout
+}
+
+func (c *command) Stderr() io.Reader {
+	return c.stderr
+}
+
+func (c *command) Stdin() io.Writer {
+	return c.stdin
+}
+
+func (c *command) Wait() error {
+	err := c.cmd.Wait()
+	wgAll.Done()
+	c.span.Finish()
+	return err
+}
+
+// WaitAll waits for all Commands to finish
+func WaitAll() error {
+	wgAll.Wait()
+}

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -4,7 +4,7 @@ import "io"
 
 func StdinPipe(c *command) (err error) {
 	c.stdin, err = c.cmd.StdinPipe()
-	return
+	return err
 }
 
 func StdinWriter(b io.Reader) Option {
@@ -16,6 +16,7 @@ func StdinWriter(b io.Reader) Option {
 
 func StdoutPipe(c *command) (err error) {
 	c.stdout, err = c.cmd.StdoutPipe()
+	return err
 }
 
 func StdoutWriter(b io.Writer) Option {
@@ -27,6 +28,7 @@ func StdoutWriter(b io.Writer) Option {
 
 func StderrPipe(c *command) (err error) {
 	c.stderr, err = c.cmd.StderrPipe()
+	return err
 }
 
 func StderrWriter(b io.Writer) Option {

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -1,0 +1,37 @@
+package command
+
+import "io"
+
+func StdinPipe(c *command) (err error) {
+	c.stdin, err = c.cmd.StdinPipe()
+	return
+}
+
+func StdinWriter(b io.Reader) Option {
+	return func(c *command) error {
+		c.cmd.Stdin = b
+		return nil
+	}
+}
+
+func StdoutPipe(c *command) (err error) {
+	c.stdout, err = c.cmd.StdoutPipe()
+}
+
+func StdoutWriter(b io.Writer) Option {
+	return func(c *command) error {
+		c.cmd.Stdout = b
+		return nil
+	}
+}
+
+func StderrPipe(c *command) (err error) {
+	c.stderr, err = c.cmd.StderrPipe()
+}
+
+func StderrWriter(b io.Writer) Option {
+	return func(c *command) error {
+		c.cmd.Stderr = b
+		return nil
+	}
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -308,7 +308,7 @@ type TreeEntry struct {
 
 //Tree returns the files and folders at a given ref at a path in a repository
 func (r *LocalRepository) Tree(ctx context.Context, ref, path string) ([]TreeEntry, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "storage.Server.Tree")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "storage.LocalRepository.Tree")
 	span.SetTag("ref", ref)
 	span.SetTag("path", path)
 	defer span.Finish()
@@ -327,7 +327,7 @@ func (r *LocalRepository) Tree(ctx context.Context, ref, path string) ([]TreeEnt
 }
 
 func (r *LocalRepository) tree(ctx context.Context, ref, path string) ([]TreeEntry, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "storage.Server.tree")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "storage.LocalRepository.tree")
 	span.SetTag("ref", ref)
 	span.SetTag("path", path)
 	defer span.Finish()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -77,7 +77,7 @@ func (s *LocalStorage) Create(ctx context.Context, id string) error {
 	}
 
 	errBuf := &bytes.Buffer{}
-	cmd, err := command.New(ctx, nil, nil, errBuf, dir, s.git, "init", "--bare")
+	cmd, err := command.New(ctx, dir, s.git, []string{"init", "--bare"}, command.StderrWriter(errBuf))
 	if err != nil {
 		injectError(span, err, "")
 	}
@@ -131,7 +131,7 @@ func (r *LocalRepository) ListBranches(ctx context.Context) ([]Branch, error) {
 
 	errBuf := &bytes.Buffer{}
 	args := []string{"for-each-ref", "--format=%(objectname) %(objecttype) %(refname)", "refs/heads"}
-	cmd, err := command.New(ctx, nil, nil, errBuf, r.path, r.git, args...)
+	cmd, err := command.New(ctx, r.path, r.git, args, command.StderrWriter(errBuf), command.StdoutPipe)
 	if err != nil {
 		injectError(span, err, "")
 		return nil, err
@@ -183,7 +183,7 @@ func (r *LocalRepository) GetCommit(ctx context.Context, ref string) (Commit, er
 
 	errBuf := &bytes.Buffer{}
 	args := []string{"cat-file", "-p", ref}
-	cmd, err := command.New(ctx, nil, nil, errBuf, r.path, r.git, args...)
+	cmd, err := command.New(ctx, r.path, r.git, args, command.StderrWriter(errBuf), command.StdoutPipe)
 	if err != nil {
 		injectError(span, err, errBuf.String())
 		return Commit{}, err
@@ -329,7 +329,7 @@ func (r *LocalRepository) tree(ctx context.Context, ref, path string) ([]TreeEnt
 
 	errBuf := &bytes.Buffer{}
 	args := []string{"ls-tree", ref, path}
-	cmd, err := command.New(ctx, nil, nil, errBuf, r.path, r.git, args...)
+	cmd, err := command.New(ctx, r.path, r.git, args, command.StderrWriter(errBuf), command.StdoutPipe)
 	if err != nil {
 		injectError(span, err, errBuf.String())
 		return nil, errors.Wrap(err, "failed to run git ls-tree")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -97,19 +97,14 @@ func (s *LocalStorage) GetRepository(ctx context.Context, repoPath string) (Repo
 	defer span.Finish()
 	dir := s.repoPath(repoPath)
 
-	outBuf := &bytes.Buffer{}
-	cmd, err := command.New(ctx, nil, outBuf, outBuf, dir, s.git, "config", "--null", "core.repositoryformatversion")
+	out, err := command.NewSimple(ctx, dir, s.git, "config", "--null", "core.repositoryformatversion")
 	if err != nil {
-		injectError(span, err, "")
-		return nil, ErrRepoNotValid
-	}
-	if err := cmd.Wait(); err != nil {
-		injectError(span, err, outBuf.String())
+		injectError(span, err, out)
 		return nil, ErrRepoNotValid
 	}
 
-	if strings.TrimSuffix(outBuf.String(), "\x00") != "0" {
-		injectError(span, ErrRepoNotValid, outBuf.String())
+	if strings.TrimSuffix(out, "\x00") != "0" {
+		injectError(span, ErrRepoNotValid, out)
 		return nil, ErrRepoNotValid
 	}
 


### PR DESCRIPTION
Move all shell-outs into a package. Makes them easy to track and instrument.
![screenshot_2019-02-15 jaeger ui](https://user-images.githubusercontent.com/4726179/52828489-4bd01a80-30c9-11e9-9693-cd75a0c055e1.png)

On error:
![screenshot_2019-02-15 jaeger ui 1](https://user-images.githubusercontent.com/4726179/52828550-85088a80-30c9-11e9-9894-f53929927341.png)
![screenshot_2019-02-15 jaeger ui 2](https://user-images.githubusercontent.com/4726179/52828626-cef17080-30c9-11e9-95d4-3e63ad0fab24.png)
