### PR TITLE
Remove env vars except the wanted ones

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -53,14 +53,12 @@ var (
 	apiFlags = []cli.Flag{
 		cli.StringFlag{
 			Name:        cmd.FlagAPIPrefix,
-			EnvVar:      cmd.EnvAPIPrefix,
 			Usage:       "The prefix the api is serving from, default: /",
 			Value:       "/",
 			Destination: &apiConfig.APIPrefix,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagDatabaseDriver,
-			EnvVar:      cmd.EnvDatabaseDriver,
 			Usage:       "The database driver to use: memory & postgres",
 			Value:       "postgres",
 			Destination: &apiConfig.DatabaseDriver,
@@ -73,27 +71,23 @@ var (
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagHTTPAddr,
-			EnvVar:      cmd.EnvHTTPAddr,
 			Usage:       "The address SourcePods API runs on",
 			Value:       ":3020",
 			Destination: &apiConfig.HTTPAddr,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagHTTPPrivateAddr,
-			EnvVar:      cmd.EnvHTTPPrivateAddr,
 			Usage:       "The address SourcePods runs a http server only for internal access",
 			Value:       ":3021",
 			Destination: &apiConfig.HTTPPrivateAddr,
 		},
 		cli.BoolFlag{
 			Name:        cmd.FlagLogJSON,
-			EnvVar:      cmd.EnvLogJSON,
 			Usage:       "The logger will log json lines",
 			Destination: &apiConfig.LogJSON,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagLogLevel,
-			EnvVar:      cmd.EnvLogLevel,
 			Usage:       "The log level to filter logs with before printing",
 			Value:       "info",
 			Destination: &apiConfig.LogLevel,
@@ -106,19 +100,16 @@ var (
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagStorageGRPCURL,
-			EnvVar:      cmd.EnvStorageGRPCURL,
 			Usage:       "The storage's gprc url to connect with",
 			Destination: &apiConfig.StorageGRPCURL,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagStorageHTTPURL,
-			EnvVar:      cmd.EnvStorageHTTPURL,
 			Usage:       "The storage's http url to proxy to",
 			Destination: &apiConfig.StorageHTTPURL,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagTracingURL,
-			EnvVar:      cmd.EnvTracingURL,
 			Usage:       "The url to send spans for tracing to",
 			Destination: &apiConfig.TracingURL,
 		},

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -41,7 +40,6 @@ type apiConf struct {
 	DatabaseDSN     string
 	LogJSON         bool
 	LogLevel        string
-	Secret          string
 	StorageGRPCURL  string
 	StorageHTTPURL  string
 	TracingURL      string
@@ -93,12 +91,6 @@ var (
 			Destination: &apiConfig.LogLevel,
 		},
 		cli.StringFlag{
-			Name:        cmd.FlagSecret,
-			EnvVar:      cmd.EnvSecret,
-			Usage:       "This secret is going to be used to generate cookies",
-			Destination: &apiConfig.Secret,
-		},
-		cli.StringFlag{
 			Name:        cmd.FlagStorageGRPCURL,
 			Usage:       "The storage's gprc url to connect with",
 			Destination: &apiConfig.StorageGRPCURL,
@@ -117,10 +109,6 @@ var (
 )
 
 func apiAction(c *cli.Context) error {
-	if apiConfig.Secret == "" {
-		return errors.New("the secret for the api can't be empty")
-	}
-
 	logger := cmd.NewLogger(apiConfig.LogJSON, apiConfig.LogLevel)
 	logger = log.WithPrefix(logger, "app", c.App.Name)
 

--- a/cmd/api/db.go
+++ b/cmd/api/db.go
@@ -23,7 +23,6 @@ var (
 	dbFlags = []cli.Flag{
 		cli.StringFlag{
 			Name:        cmd.FlagDatabaseDriver,
-			EnvVar:      cmd.EnvDatabaseDriver,
 			Usage:       "The database driver to use: memory & postgres",
 			Value:       "postgres",
 			Destination: &dbConfig.DatabaseDriver,
@@ -36,7 +35,6 @@ var (
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagMigrationsPath,
-			EnvVar:      cmd.EnvMigrationsPath,
 			Usage:       "The path to the folder containing all migrations",
 			Destination: &dbConfig.MigrationsPath,
 		},

--- a/cmd/api/users.go
+++ b/cmd/api/users.go
@@ -30,7 +30,6 @@ var (
 	usersFlags = []cli.Flag{
 		cli.StringFlag{
 			Name:        cmd.FlagDatabaseDriver,
-			EnvVar:      cmd.EnvDatabaseDriver,
 			Usage:       "The database driver to use: postgres",
 			Value:       "postgres",
 			Destination: &usersConfig.DatabaseDriver,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -20,15 +20,14 @@ const (
 	FlagLogLevel        = "log-level"
 	FlagMigrationsPath  = "migrations-path"
 	FlagRoot            = "root"
-	FlagSecret          = "secret"
 	FlagSSHAddr         = "ssh-addr"
 	FlagSSHHostKeyPath  = "ssh-host-key"
 	FlagStorageGRPCURL  = "storage-grpc-url"
 	FlagStorageHTTPURL  = "storage-http-url"
 	FlagTracingURL      = "tracing-url"
 
+	//EnvDatabaseDSN is the data source name string to connect to the database with
 	EnvDatabaseDSN = "GITPODS_DATABASE_DSN"
-	EnvSecret      = "GITPODS_SECRET"
 )
 
 func NewLogger(json bool, loglevel string) log.Logger {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,23 +27,8 @@ const (
 	FlagStorageHTTPURL  = "storage-http-url"
 	FlagTracingURL      = "tracing-url"
 
-	EnvAPIPrefix       = "GITPODS_API_PREFIX"
-	EnvAPIURL          = "GITPODS_API_URL"
-	EnvDatabaseDriver  = "GITPODS_DATABASE_DRIVER"
-	EnvDatabaseDSN     = "GITPODS_DATABASE_DSN"
-	EnvGRPCAddr        = "GITPODS_GRPC_ADDR"
-	EnvHTTPAddr        = "GITPODS_HTTP_ADDR"
-	EnvHTTPPrivateAddr = "GITPODS_HTTP_PRIVATE_ADDR"
-	EnvLogJSON         = "GITPODS_LOG_JSON"
-	EnvLogLevel        = "GITPODS_LOG_LEVEL"
-	EnvMigrationsPath  = "GITPODS_MIGRATIONS_PATH"
-	EnvRoot            = "GITPODS_ROOT"
-	EnvSecret          = "GITPODS_SECRET"
-	EnvSSHAddr         = "GITPODS_SSH_ADDR"
-	EnvSSHHostKeyPath  = "GITPODS_SSH_HOST_KEY"
-	EnvStorageGRPCURL  = "GITPODS_STORAGE_GRPC_URL"
-	EnvStorageHTTPURL  = "GITPODS_STORAGE_HTTP_URL"
-	EnvTracingURL      = "GITPODS_TRACING_URL"
+	EnvDatabaseDSN = "GITPODS_DATABASE_DSN"
+	EnvSecret      = "GITPODS_SECRET"
 )
 
 func NewLogger(json bool, loglevel string) log.Logger {

--- a/cmd/sourcepods-dev/dev.go
+++ b/cmd/sourcepods-dev/dev.go
@@ -130,7 +130,6 @@ func devAction(c *cli.Context) error {
 
 	apiRunner := NewRunner("api", []string{
 		fmt.Sprintf("%s=%s", cmd.EnvDatabaseDSN, databaseDSNFlag),
-		fmt.Sprintf("%s=%s", cmd.EnvSecret, "secret"),
 	}, []string{
 		fmt.Sprintf("--%s=%s", cmd.FlagHTTPAddr, apiAddrFlag),
 		fmt.Sprintf("--%s=%s", cmd.FlagLogLevel, loglevelFlag),

--- a/cmd/sourcepods-dev/dev.go
+++ b/cmd/sourcepods-dev/dev.go
@@ -120,41 +120,41 @@ func devAction(c *cli.Context) error {
 		}
 	}
 
-	uiRunner := NewRunner("ui", []string{
-		fmt.Sprintf("%s=%s", cmd.EnvHTTPAddr, uiAddrFlag),
-		fmt.Sprintf("%s=%s", cmd.EnvAPIURL, "http://localhost:3000/api"), // TODO
-		fmt.Sprintf("%s=%s", cmd.EnvLogLevel, loglevelFlag),
-		fmt.Sprintf("%s=%v", cmd.EnvLogJSON, logJSONFlag),
-		fmt.Sprintf("%s=%v", cmd.EnvTracingURL, tracingURL),
+	uiRunner := NewRunner("ui", []string{}, []string{
+		fmt.Sprintf("--%s=%s", cmd.FlagAPIURL, "http://localhost:3000/api"), // TODO
+		fmt.Sprintf("--%s=%s", cmd.FlagHTTPAddr, uiAddrFlag),
+		fmt.Sprintf("--%s=%s", cmd.FlagLogLevel, loglevelFlag),
+		fmt.Sprintf("--%s=%s", cmd.FlagTracingURL, tracingURL),
+		fmt.Sprintf("--%s=%v", cmd.FlagLogJSON, logJSONFlag),
 	})
 
 	apiRunner := NewRunner("api", []string{
-		fmt.Sprintf("%s=%s", cmd.EnvHTTPAddr, apiAddrFlag),
 		fmt.Sprintf("%s=%s", cmd.EnvDatabaseDSN, databaseDSNFlag),
-		fmt.Sprintf("%s=%s", cmd.EnvMigrationsPath, "./schema/postgres"),
-		fmt.Sprintf("%s=%s", cmd.EnvLogLevel, loglevelFlag),
-		fmt.Sprintf("%s=%v", cmd.EnvLogJSON, logJSONFlag),
 		fmt.Sprintf("%s=%s", cmd.EnvSecret, "secret"),
-		fmt.Sprintf("%s=%s", cmd.EnvStorageGRPCURL, "localhost:3033"),
-		fmt.Sprintf("%s=%s", cmd.EnvStorageHTTPURL, "http://localhost:3030"),
-		fmt.Sprintf("%s=%v", cmd.EnvTracingURL, tracingURL),
+	}, []string{
+		fmt.Sprintf("--%s=%s", cmd.FlagHTTPAddr, apiAddrFlag),
+		fmt.Sprintf("--%s=%s", cmd.FlagLogLevel, loglevelFlag),
+		fmt.Sprintf("--%s=%s", cmd.FlagStorageGRPCURL, "localhost:3033"),
+		fmt.Sprintf("--%s=%s", cmd.FlagStorageHTTPURL, "http://localhost:3030"),
+		fmt.Sprintf("--%s=%s", cmd.FlagTracingURL, tracingURL),
+		fmt.Sprintf("--%s=%v", cmd.FlagLogJSON, logJSONFlag),
 	})
 
-	storageRunner := NewRunner("storage", []string{
-		fmt.Sprintf("%s=%s", cmd.EnvHTTPAddr, storageAddrFlag),
-		fmt.Sprintf("%s=%s", cmd.EnvLogLevel, loglevelFlag),
-		fmt.Sprintf("%s=%v", cmd.EnvLogJSON, logJSONFlag),
-		fmt.Sprintf("%s=%s", cmd.EnvRoot, storageRootFlag),
-		fmt.Sprintf("%s=%v", cmd.EnvTracingURL, tracingURL),
+	storageRunner := NewRunner("storage", []string{}, []string{
+		fmt.Sprintf("--%s=%s", cmd.FlagHTTPAddr, storageAddrFlag),
+		fmt.Sprintf("--%s=%s", cmd.FlagLogLevel, loglevelFlag),
+		fmt.Sprintf("--%s=%s", cmd.FlagRoot, storageRootFlag),
+		fmt.Sprintf("--%s=%s", cmd.FlagTracingURL, tracingURL),
+		fmt.Sprintf("--%s=%v", cmd.FlagLogJSON, logJSONFlag),
 	})
 
-	sshRunner := NewRunner("ssh", []string{
-		fmt.Sprintf("%s=%s", cmd.EnvSSHAddr, sshAddrFlag),
-		fmt.Sprintf("%s=%s", cmd.EnvSSHHostKeyPath, "./dev/keys/"),
-		fmt.Sprintf("%s=%s", cmd.EnvStorageGRPCURL, "localhost:3033"),
-		fmt.Sprintf("%s=%s", cmd.EnvLogLevel, loglevelFlag),
-		fmt.Sprintf("%s=%v", cmd.EnvLogJSON, logJSONFlag),
-		fmt.Sprintf("%s=%v", cmd.EnvTracingURL, tracingURL),
+	sshRunner := NewRunner("ssh", []string{}, []string{
+		fmt.Sprintf("--%s=%s", cmd.FlagLogLevel, loglevelFlag),
+		fmt.Sprintf("--%s=%s", cmd.FlagSSHAddr, sshAddrFlag),
+		fmt.Sprintf("--%s=%s", cmd.FlagSSHHostKeyPath, "./dev/keys/"),
+		fmt.Sprintf("--%s=%s", cmd.FlagStorageGRPCURL, "localhost:3033"),
+		fmt.Sprintf("--%s=%s", cmd.FlagTracingURL, tracingURL),
+		fmt.Sprintf("--%s=%v", cmd.FlagLogJSON, logJSONFlag),
 	})
 
 	caddy := CaddyRunner{}

--- a/cmd/sourcepods-dev/runner.go
+++ b/cmd/sourcepods-dev/runner.go
@@ -21,6 +21,7 @@ type Runner struct {
 	restart chan bool
 }
 
+//NewRunner creates a Runner that can be restarted
 func NewRunner(name string, env []string, args []string) *Runner {
 	return &Runner{
 		name:    name,
@@ -30,10 +31,12 @@ func NewRunner(name string, env []string, args []string) *Runner {
 	}
 }
 
+//Name of the Runner
 func (r *Runner) Name() string {
 	return r.name
 }
 
+//Run the command
 func (r *Runner) Run() error {
 	if err := r.Build(); err == nil {
 		r.restart <- true
@@ -84,6 +87,7 @@ func (r *Runner) Run() error {
 	}
 }
 
+//Stop the command and process
 func (r *Runner) Stop() {
 	if r.cmd == nil || r.cmd.Process == nil {
 		return
@@ -91,6 +95,7 @@ func (r *Runner) Stop() {
 	r.cmd.Process.Kill()
 }
 
+//Build the binary to be run afterwards. Example: make dev/api
 func (r *Runner) Build() error {
 	cmd := exec.Command("make", "dev/"+r.name)
 	cmd.Stdin = os.Stdin
@@ -102,10 +107,12 @@ func (r *Runner) Build() error {
 	return cmd.Run()
 }
 
+//Restart the program by signaling via restart channel
 func (r *Runner) Restart() {
 	r.restart <- true
 }
 
+//Shutdown the program by closing the restart channel and stopping the process
 func (r *Runner) Shutdown() {
 	close(r.restart)
 	r.Stop()
@@ -116,6 +123,7 @@ type CaddyRunner struct {
 	cmd *exec.Cmd
 }
 
+//Run Caddy and print its output
 func (r *CaddyRunner) Run() error {
 	r.cmd = exec.Command(filepath.Join(".", "dev", "caddy"), "-conf", "./dev/Caddyfile")
 	stdout, err := r.cmd.StdoutPipe()
@@ -142,6 +150,7 @@ func (r *CaddyRunner) Run() error {
 	return r.cmd.Wait()
 }
 
+//Stop Caddy server
 func (r *CaddyRunner) Stop() {
 	if r.cmd == nil || r.cmd.Process == nil {
 		return

--- a/cmd/sourcepods-dev/runner.go
+++ b/cmd/sourcepods-dev/runner.go
@@ -50,11 +50,9 @@ func (r *Runner) Run() error {
 			}
 
 			go func() {
-				r.cmd = exec.Command("./dev/" + r.name)
+				r.cmd = exec.Command("./dev/"+r.name, r.args...)
 				r.cmd.Env = r.env
-				r.cmd.Args = r.args
-
-				color.HiGreen("%s %s\n", r.cmd.Path, strings.Join(r.cmd.Args, " "))
+				color.HiGreen("%s\n", strings.Join(r.cmd.Args, " "))
 
 				stdout, err := r.cmd.StdoutPipe()
 				if err != nil {

--- a/cmd/sourcepods-dev/runner.go
+++ b/cmd/sourcepods-dev/runner.go
@@ -16,14 +16,16 @@ import (
 type Runner struct {
 	name    string
 	env     []string
+	args    []string
 	cmd     *exec.Cmd
 	restart chan bool
 }
 
-func NewRunner(name string, env []string) *Runner {
+func NewRunner(name string, env []string, args []string) *Runner {
 	return &Runner{
 		name:    name,
 		env:     env,
+		args:    args,
 		restart: make(chan bool, 16),
 	}
 }
@@ -47,6 +49,10 @@ func (r *Runner) Run() error {
 			go func() {
 				r.cmd = exec.Command("./dev/" + r.name)
 				r.cmd.Env = r.env
+				r.cmd.Args = r.args
+
+				color.HiGreen("%s %s\n", r.cmd.Path, strings.Join(r.cmd.Args, " "))
+
 				stdout, err := r.cmd.StdoutPipe()
 				if err != nil {
 					return

--- a/cmd/sourcepods-dev/watcher.go
+++ b/cmd/sourcepods-dev/watcher.go
@@ -10,20 +10,24 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+//BuildRestarter builds a new binary and then restarts the program
 type BuildRestarter interface {
 	Name() string
 	Build() error
 	Restart()
 }
 
+//FileWatcher watches Go files and builds then restart on changes
 type FileWatcher struct {
 	Restarters []BuildRestarter
 }
 
+//Add a new BuildRestarter to restart on changes
 func (w *FileWatcher) Add(r ...BuildRestarter) {
 	w.Restarters = append(w.Restarters, r...)
 }
 
+//Watch Go files and trigger restarts after successful builds
 func (w *FileWatcher) Watch() {
 	// TODO: Find new/deleted Go files not only on start, but also while running
 	files, err := w.findGoFiles()

--- a/cmd/ssh/ssh.go
+++ b/cmd/ssh/ssh.go
@@ -32,40 +32,34 @@ var (
 	sshFlags  = []cli.Flag{
 		cli.StringFlag{
 			Name:        cmd.FlagSSHAddr,
-			EnvVar:      cmd.EnvSSHAddr,
 			Value:       ":3022",
 			Usage:       "The SSH address to listen on",
 			Destination: &sshConfig.SSHAddr,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagSSHHostKeyPath,
-			EnvVar:      cmd.EnvSSHHostKeyPath,
 			Value:       "/etc/ssh/",
 			Usage:       "The path to looks for ssh host-keys in",
 			Destination: &sshConfig.HostKeyPath,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagStorageGRPCURL,
-			EnvVar:      cmd.EnvStorageGRPCURL,
 			Usage:       "The storage's grpc url to connect with",
 			Destination: &sshConfig.StorageGRPCURL,
 		},
 		cli.BoolFlag{
 			Name:        cmd.FlagLogJSON,
-			EnvVar:      cmd.EnvLogJSON,
 			Usage:       "The logger will log json lines",
 			Destination: &sshConfig.LogJSON,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagLogLevel,
-			EnvVar:      cmd.EnvLogLevel,
 			Usage:       "The log level to filter logs with before printing",
 			Value:       "info",
 			Destination: &sshConfig.LogLevel,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagTracingURL,
-			EnvVar:      cmd.EnvTracingURL,
 			Usage:       "The url to send spans for tracing to",
 			Destination: &sshConfig.TracingURL,
 		},

--- a/cmd/storage/storage.go
+++ b/cmd/storage/storage.go
@@ -36,38 +36,32 @@ var (
 	storageFlags = []cli.Flag{
 		cli.StringFlag{
 			Name:        cmd.FlagGRPCAddr,
-			EnvVar:      cmd.EnvGRPCAddr,
 			Value:       ":3033",
 			Destination: &storageConfig.GRPCAddr,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagHTTPAddr,
-			EnvVar:      cmd.EnvHTTPAddr,
 			Value:       ":3030",
 			Destination: &storageConfig.HTTPAddr,
 		},
 		cli.BoolFlag{
 			Name:        cmd.FlagLogJSON,
-			EnvVar:      cmd.EnvLogJSON,
 			Usage:       "The logger will log json lines",
 			Destination: &storageConfig.LogJSON,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagLogLevel,
-			EnvVar:      cmd.EnvLogLevel,
 			Usage:       "The log level to filter logs with before printing",
 			Value:       "info",
 			Destination: &storageConfig.LogLevel,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagRoot,
-			EnvVar:      cmd.EnvRoot,
 			Usage:       "The root folder to store all git repositories in",
 			Destination: &storageConfig.Root,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagTracingURL,
-			EnvVar:      cmd.EnvTracingURL,
 			Usage:       "The url to send spans for tracing to",
 			Destination: &storageConfig.TracingURL,
 		},

--- a/cmd/ui/ui.go
+++ b/cmd/ui/ui.go
@@ -26,27 +26,23 @@ var (
 	uiFlags = []cli.Flag{
 		cli.StringFlag{
 			Name:        cmd.FlagAPIURL,
-			EnvVar:      cmd.EnvAPIURL,
 			Usage:       "The address SourcePods API runs on",
 			Value:       ":3020",
 			Destination: &uiConfig.AddrAPI,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagHTTPAddr,
-			EnvVar:      cmd.EnvHTTPAddr,
 			Usage:       "The address SourcePods UI runs on",
 			Value:       ":3010",
 			Destination: &uiConfig.Addr,
 		},
 		cli.BoolFlag{
 			Name:        cmd.FlagLogJSON,
-			EnvVar:      cmd.EnvLogJSON,
 			Usage:       "The logger will log json lines",
 			Destination: &uiConfig.LogJson,
 		},
 		cli.StringFlag{
 			Name:        cmd.FlagLogLevel,
-			EnvVar:      cmd.EnvLogLevel,
 			Usage:       "The log level to filter logs with before printing",
 			Value:       "info",
 			Destination: &uiConfig.LogLevel,


### PR DESCRIPTION
These are the only two env vars we keep:
```go
EnvDatabaseDSN = "GITPODS_DATABASE_DSN"
EnvSecret      = "GITPODS_SECRET"
```

PTAL @bkcsoft 

Closes #34 